### PR TITLE
feat: add prefix handling for shortcuts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export async function transformAlias(
   if (typeof keep === 'string')
     keep = { prefix: keep, block: true }
 
-  const extraRE = new RegExp(`(${escapeRegExp(prefix)}|${escapeRegExp(keep.prefix)})([\:\\w-]+)`, 'g')
+  const extraRE = new RegExp(`(${escapeRegExp(prefix)}|${escapeRegExp(keep.prefix)})([\\w-:]+)`, 'g')
   const map = new Map<string, ShortcutValue | false>()
 
   for (const item of Array.from(code.original.matchAll(extraRE))) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export async function transformAlias(
   if (typeof keep === 'string')
     keep = { prefix: keep, block: true }
 
-  const extraRE = new RegExp(`(${escapeRegExp(prefix)}|${escapeRegExp(keep.prefix)})([\\w-]+)`, 'g')
+  const extraRE = new RegExp(`(${escapeRegExp(prefix)}|${escapeRegExp(keep.prefix)})([\:\\w-]+)`, 'g')
   const map = new Map<string, ShortcutValue | false>()
 
   for (const item of Array.from(code.original.matchAll(extraRE))) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -8,6 +8,7 @@ const uno = createGenerator({
   shortcuts: [
     ['btn', 'text-(white xl) font-bold py-2 px-4 rounded cursor-pointer'],
     [/^btn-(.+)$/, ([,d]) => `bg-${d}-500 hover:bg-${d}-700 btn`],
+    [/^tapped:(.*)$/, ([, c]) => `hover:${c} active:${c}`],
   ],
 })
 
@@ -31,6 +32,7 @@ describe('transformer alias', () => {
   <div *btn>
     <div text-xl class="*btn-red" />
     <div *btn-teal />
+    <div text-red *tapped:text-blue />
   </div>
 </template>
     `.trim()
@@ -40,6 +42,7 @@ describe('transformer alias', () => {
         <div text-white text-xl font-bold py-2 px-4 rounded cursor-pointer>
           <div text-xl class="bg-red-500 hover:bg-red-700 text-white text-xl font-bold py-2 px-4 rounded cursor-pointer" />
           <div bg-teal-500 hover:bg-teal-700 text-white text-xl font-bold py-2 px-4 rounded cursor-pointer />
+          <div text-red hover:text-blue active:text-blue />
         </div>
       </template>"
     `)
@@ -53,6 +56,8 @@ describe('transformer alias', () => {
   <div &test-none>
     <div text-xl class="&btn-red" />
     <div *btn-red />
+    <div *tapped:text-blue />
+    <div &tapped:text-blue />
   </div>
 </template>
     `.trim()
@@ -62,6 +67,8 @@ describe('transformer alias', () => {
         <div &test-none>
           <div text-xl class="bg-red-500 hover:bg-red-700 text-white text-xl font-bold py-2 px-4 rounded cursor-pointer" />
           <div *btn-red />
+          <div *tapped:text-blue />
+          <div hover:text-blue active:text-blue />
         </div>
       </template>"
     `)
@@ -72,6 +79,8 @@ describe('transformer alias', () => {
     <template>
         <div class="*btn-red" />
         <div *btn-red />
+        <div class="*tapped:text-blue" />
+        <div *tapped:text-blue />
     </template>
         `.trim()
     const transform = createTransformer()
@@ -80,6 +89,8 @@ describe('transformer alias', () => {
       "<template>
               <div class="bg-red-500 hover:bg-red-700 text-white text-xl font-bold py-2 px-4 rounded cursor-pointer" />
               <div bg-red-500 hover:bg-red-700 text-white text-xl font-bold py-2 px-4 rounded cursor-pointer />
+              <div class="hover:text-blue active:text-blue" />
+              <div hover:text-blue active:text-blue />
           </template>"
     `)
 
@@ -96,6 +107,16 @@ describe('transformer alias', () => {
             "px-4",
             "rounded",
             "cursor-pointer",
+          ],
+        ]
+      `)
+
+    expect(await expandShortcut('tapped:text-blue', uno))
+      .toMatchInlineSnapshot(`
+        [
+          [
+            "hover:text-blue",
+            "active:text-blue",
           ],
         ]
       `)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -110,16 +110,6 @@ describe('transformer alias', () => {
           ],
         ]
       `)
-
-    expect(await expandShortcut('tapped:text-blue', uno))
-      .toMatchInlineSnapshot(`
-        [
-          [
-            "hover:text-blue",
-            "active:text-blue",
-          ],
-        ]
-      `)
   })
 
   it('keep shortcut with prefix', async () => {


### PR DESCRIPTION
Hello!

Thanks for this awesome plugin, I was using it for some time, and stumbled across issue with shortcuts using prefix. This feature was badly needed so I experimented a little before doing a fork.

## Description

This adds capturing of `:` into the regex that will allow for doing a shortcut in a prefixed-style like so: `*tapped:text-blue` into `hover:text-blue active:text-blue`.

Let me know if I should improve the tests, or add more/split them up.

Apologies for not creating issue first, but since I already had a solution at hand I created a PR asap.